### PR TITLE
Add retry implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,24 @@ async function stop() {
 }
 
 (async function () {
-  try {
-    config.input.mode === 'start' ? await start() : await stop();
-  } catch (error) {
-    core.error(error);
-    core.setFailed(error.message);
-  }
+  const MAX_ATTEMPTS = Number.parseInt(core.getInput('max_attempts'));
+  let attempt = 0;
+  let hasSucceeded = false;
+  do {
+    try {
+      config.input.mode === 'start' ? await start() : await stop();
+      hasSucceeded = true;
+    } catch (error) {
+      await sleep(5000);
+      attempt += 1;
+      core.warning(`Attempt ${attempt} of ${MAX_ATTEMPTS}`);
+      if (attempt >= MAX_ATTEMPTS) {
+        core.error('Max attempts exceeded');
+        core.error(error);
+        core.setFailed(error.message);
+      } else {
+        core.warning(`${error} - ${error.message}`);
+      }
+    }
+  } while (attempt < MAX_ATTEMPTS && !hasSucceeded);
 })();


### PR DESCRIPTION
Inspired by https://github.com/machulav/ec2-github-runner/pull/80
and sleep 5 seconds before each retry to avoid RequestLimitExceeded
error when launching multiple ec2 instances.